### PR TITLE
Fix VMX Check (whiz-vmm-vmx_root)

### DIFF
--- a/ymir/arch/x86/arch.zig
+++ b/ymir/arch/x86/arch.zig
@@ -39,7 +39,7 @@ pub fn getCpuVendorId() [12]u8 {
 /// Check if virtualization technology is supported.
 pub fn isVmxSupported() bool {
     // Check CPUID if VMX is supported.
-    const regs = cpuid.Leaf.query(.ext_feature, null);
+    const regs = cpuid.Leaf.query(.vers_and_feat_info, null);
     const ecx: cpuid.FeatureInfoEcx = @bitCast(regs.ecx);
     if (!ecx.vmx) return false;
 

--- a/ymir/arch/x86/cpuid.zig
+++ b/ymir/arch/x86/cpuid.zig
@@ -3,8 +3,8 @@
 pub const Leaf = enum(u32) {
     /// Maximum input value for basic CPUID.
     maximum_input = 0x0,
-    /// Version information.
-    version_info = 0x1,
+    /// Version and feature information.
+    vers_and_feat_info = 0x1,
     /// Thermal and power management.
     thermal_power = 0x6,
     /// Structured extended feature enumeration.


### PR DESCRIPTION
For some reason the Leaf.ext_feature (0x7) is used for the VMX check, even though version_info (0x1) should be used. This also renames Leaf.version_info to vers_and_feat_info to be more descriptive since 2 of the 4 registers are just feature flags.

@smallkirby this also has to be fixed in subsequent branches, do you want to cherry-pick the commits into those, or should I open PRs for those as well?