### PR TITLE
fix guest registers restore logic

### DIFF
--- a/ymir/arch/x86/vmx/asm.zig
+++ b/ymir/arch/x86/vmx/asm.zig
@@ -42,7 +42,7 @@ export fn asmVmEntry() callconv(.naked) u8 {
 
     // Restore guest registers.
     asm volatile (std.fmt.comptimePrint(
-            \\mov {[guest_regs]}(%%rdi), %%rax
+            \\lea {[guest_regs]}(%%rdi), %%rax
             \\mov {[rcx]}(%%rax), %%rcx
             \\mov {[rdx]}(%%rax), %%rdx
             \\mov {[rbx]}(%%rax), %%rbx


### PR DESCRIPTION
I noticed that `asmVmEntry` seems to be restoring guest registers without adding the offset of the `guest_regs` field, so I added that in. This should point to the correct address within the `Vcpu` struct.

That said, I’m on an AMD machine, so I couldn’t actually test this on Intel hardware. Also, there's a chance I misunderstood how this part is supposed to work—feel free to correct me if that's the case!